### PR TITLE
Fix for 7z issue

### DIFF
--- a/snes_bc831044-f772-4391-8c22-529f42cb9799/plugin.py
+++ b/snes_bc831044-f772-4391-8c22-529f42cb9799/plugin.py
@@ -48,7 +48,8 @@ class Retroarch(Plugin):
             with open(self.playlist_path) as playlist_json:
                 playlist_dict = json.load(playlist_json)
             for entry in playlist_dict["items"]:
-                if os.path.abspath(user_config.rom_path) in os.path.abspath(entry["path"]) and os.path.isfile(entry["path"]):
+                rom_path = entry["path"].split("#")[0]
+                if os.path.abspath(user_config.rom_path) in os.path.abspath(rom_path) and os.path.isfile(rom_path):
                     provided_name = entry["label"].split(" (")[0]
                     if provided_name in corrections.correction_list:
                         correct_name = corrections.correction_list[provided_name]


### PR DESCRIPTION
My snes playlist has entries like so:
"path": "C:\\Emulation\\Roms\\Nintendo - Super Nintendo Entertainment
System\\ActRaiser (USA).7z#ActRaiser (USA).sfc",

The view into the 7z file ("#ActRaiser (USA).sfc") causes issues
due to python not  being able to find the path. Added a fix for this.