### PR TITLE
Fix/archive support

### DIFF
--- a/3ds_f6acd3ed-2c31-47d6-bae4-07b6714c1e55/plugin.py
+++ b/3ds_f6acd3ed-2c31-47d6-bae4-07b6714c1e55/plugin.py
@@ -49,7 +49,7 @@ class Retroarch(Plugin):
                 playlist_dict = json.load(playlist_json)
             for entry in playlist_dict["items"]:
                 rom_path = entry["path"].split("#")[0]
-if os.path.abspath(user_config.rom_path) in os.path.abspath(rom_path) and os.path.isfile(rom_path):
+                if os.path.abspath(user_config.rom_path) in os.path.abspath(rom_path) and os.path.isfile(rom_path):
                     provided_name = entry["label"].split(" (")[0]
                     if provided_name in corrections.correction_list:
                         correct_name = corrections.correction_list[provided_name]

--- a/3ds_f6acd3ed-2c31-47d6-bae4-07b6714c1e55/plugin.py
+++ b/3ds_f6acd3ed-2c31-47d6-bae4-07b6714c1e55/plugin.py
@@ -48,11 +48,12 @@ class Retroarch(Plugin):
             with open(self.playlist_path) as playlist_json:
                 playlist_dict = json.load(playlist_json)
             for entry in playlist_dict["items"]:
-                if os.path.abspath(user_config.rom_path) in os.path.abspath(entry["path"]) and os.path.isfile(entry["path"]):
+                rom_path = entry["path"].split("#")[0]
+if os.path.abspath(user_config.rom_path) in os.path.abspath(rom_path) and os.path.isfile(rom_path):
                     provided_name = entry["label"].split(" (")[0]
                     if provided_name in corrections.correction_list:
                         correct_name = corrections.correction_list[provided_name]
-                    else:    
+                    else:
                         correct_name = provided_name
                     game_list.append(
                         Game(
@@ -72,7 +73,7 @@ class Retroarch(Plugin):
         #removes games when removed while running
         for entry in self.game_cache:
             if entry not in game_list:
-                self.game_cache.remove(entry)    
+                self.game_cache.remove(entry)
                 self.remove_game(entry.game_id)
 
     #runs update_game_cache in case it is started before get_owned_games. If it runs after it, it just returns self.game_cache with each game as installed
@@ -94,7 +95,7 @@ class Retroarch(Plugin):
     def shutdown(self):
         pass
 
-    #potentially give user more customization possibilities like starting in fullscreen etc 
+    #potentially give user more customization possibilities like starting in fullscreen etc
     async def launch_game(self, game_id):
         if os.path.isfile(self.playlist_path):
             with open(self.playlist_path) as playlist_json:
@@ -135,7 +136,7 @@ class Retroarch(Plugin):
                 self.proc = None
         except AttributeError:
             pass
-            
+
         self.update_game_cache()
         self.get_local_games()
 

--- a/atari_830528d9-e621-48e9-8ed4-e03a4853843e/plugin.py
+++ b/atari_830528d9-e621-48e9-8ed4-e03a4853843e/plugin.py
@@ -49,7 +49,7 @@ class Retroarch(Plugin):
                 playlist_dict = json.load(playlist_json)
             for entry in playlist_dict["items"]:
                 rom_path = entry["path"].split("#")[0]
-if os.path.abspath(user_config.rom_path) in os.path.abspath(rom_path) and os.path.isfile(rom_path):
+                if os.path.abspath(user_config.rom_path) in os.path.abspath(rom_path) and os.path.isfile(rom_path):
                     provided_name = entry["label"].split(" (")[0]
                     if provided_name in corrections.correction_list:
                         correct_name = corrections.correction_list[provided_name]

--- a/atari_830528d9-e621-48e9-8ed4-e03a4853843e/plugin.py
+++ b/atari_830528d9-e621-48e9-8ed4-e03a4853843e/plugin.py
@@ -48,11 +48,12 @@ class Retroarch(Plugin):
             with open(self.playlist_path) as playlist_json:
                 playlist_dict = json.load(playlist_json)
             for entry in playlist_dict["items"]:
-                if os.path.abspath(user_config.rom_path) in os.path.abspath(entry["path"]) and os.path.isfile(entry["path"]):
+                rom_path = entry["path"].split("#")[0]
+if os.path.abspath(user_config.rom_path) in os.path.abspath(rom_path) and os.path.isfile(rom_path):
                     provided_name = entry["label"].split(" (")[0]
                     if provided_name in corrections.correction_list:
                         correct_name = corrections.correction_list[provided_name]
-                    else:    
+                    else:
                         correct_name = provided_name
                     game_list.append(
                         Game(
@@ -72,7 +73,7 @@ class Retroarch(Plugin):
         #removes games when removed while running
         for entry in self.game_cache:
             if entry not in game_list:
-                self.game_cache.remove(entry)    
+                self.game_cache.remove(entry)
                 self.remove_game(entry.game_id)
 
     #runs update_game_cache in case it is started before get_owned_games. If it runs after it, it just returns self.game_cache with each game as installed
@@ -94,7 +95,7 @@ class Retroarch(Plugin):
     def shutdown(self):
         pass
 
-    #potentially give user more customization possibilities like starting in fullscreen etc 
+    #potentially give user more customization possibilities like starting in fullscreen etc
     async def launch_game(self, game_id):
         if os.path.isfile(self.playlist_path):
             with open(self.playlist_path) as playlist_json:
@@ -135,7 +136,7 @@ class Retroarch(Plugin):
                 self.proc = None
         except AttributeError:
             pass
-            
+
         self.update_game_cache()
         self.get_local_games()
 

--- a/dc_5d181ffd-48dc-4330-aa58-6f646e76a5c8/plugin.py
+++ b/dc_5d181ffd-48dc-4330-aa58-6f646e76a5c8/plugin.py
@@ -49,7 +49,7 @@ class Retroarch(Plugin):
                 playlist_dict = json.load(playlist_json)
             for entry in playlist_dict["items"]:
                 rom_path = entry["path"].split("#")[0]
-if os.path.abspath(user_config.rom_path) in os.path.abspath(rom_path) and os.path.isfile(rom_path):
+                if os.path.abspath(user_config.rom_path) in os.path.abspath(rom_path) and os.path.isfile(rom_path):
                     provided_name = entry["label"].split(" (")[0]
                     if provided_name in corrections.correction_list:
                         correct_name = corrections.correction_list[provided_name]

--- a/dc_5d181ffd-48dc-4330-aa58-6f646e76a5c8/plugin.py
+++ b/dc_5d181ffd-48dc-4330-aa58-6f646e76a5c8/plugin.py
@@ -48,11 +48,12 @@ class Retroarch(Plugin):
             with open(self.playlist_path) as playlist_json:
                 playlist_dict = json.load(playlist_json)
             for entry in playlist_dict["items"]:
-                if os.path.abspath(user_config.rom_path) in os.path.abspath(entry["path"]) and os.path.isfile(entry["path"]):
+                rom_path = entry["path"].split("#")[0]
+if os.path.abspath(user_config.rom_path) in os.path.abspath(rom_path) and os.path.isfile(rom_path):
                     provided_name = entry["label"].split(" (")[0]
                     if provided_name in corrections.correction_list:
                         correct_name = corrections.correction_list[provided_name]
-                    else:    
+                    else:
                         correct_name = provided_name
                     game_list.append(
                         Game(
@@ -72,7 +73,7 @@ class Retroarch(Plugin):
         #removes games when removed while running
         for entry in self.game_cache:
             if entry not in game_list:
-                self.game_cache.remove(entry)    
+                self.game_cache.remove(entry)
                 self.remove_game(entry.game_id)
 
     #runs update_game_cache in case it is started before get_owned_games. If it runs after it, it just returns self.game_cache with each game as installed
@@ -94,7 +95,7 @@ class Retroarch(Plugin):
     def shutdown(self):
         pass
 
-    #potentially give user more customization possibilities like starting in fullscreen etc 
+    #potentially give user more customization possibilities like starting in fullscreen etc
     async def launch_game(self, game_id):
         if os.path.isfile(self.playlist_path):
             with open(self.playlist_path) as playlist_json:
@@ -135,7 +136,7 @@ class Retroarch(Plugin):
                 self.proc = None
         except AttributeError:
             pass
-            
+
         self.update_game_cache()
         self.get_local_games()
 

--- a/gb_4345afe1-a2c3-4c58-93d3-373c53a90a92/plugin.py
+++ b/gb_4345afe1-a2c3-4c58-93d3-373c53a90a92/plugin.py
@@ -49,7 +49,7 @@ class Retroarch(Plugin):
                 playlist_dict = json.load(playlist_json)
             for entry in playlist_dict["items"]:
                 rom_path = entry["path"].split("#")[0]
-if os.path.abspath(user_config.rom_path) in os.path.abspath(rom_path) and os.path.isfile(rom_path):
+                if os.path.abspath(user_config.rom_path) in os.path.abspath(rom_path) and os.path.isfile(rom_path):
                     provided_name = entry["label"].split(" (")[0]
                     if provided_name in corrections.correction_list:
                         correct_name = corrections.correction_list[provided_name]

--- a/gb_4345afe1-a2c3-4c58-93d3-373c53a90a92/plugin.py
+++ b/gb_4345afe1-a2c3-4c58-93d3-373c53a90a92/plugin.py
@@ -48,11 +48,12 @@ class Retroarch(Plugin):
             with open(self.playlist_path) as playlist_json:
                 playlist_dict = json.load(playlist_json)
             for entry in playlist_dict["items"]:
-                if os.path.abspath(user_config.rom_path) in os.path.abspath(entry["path"]) and os.path.isfile(entry["path"]):
+                rom_path = entry["path"].split("#")[0]
+if os.path.abspath(user_config.rom_path) in os.path.abspath(rom_path) and os.path.isfile(rom_path):
                     provided_name = entry["label"].split(" (")[0]
                     if provided_name in corrections.correction_list:
                         correct_name = corrections.correction_list[provided_name]
-                    else:    
+                    else:
                         correct_name = provided_name
                     game_list.append(
                         Game(
@@ -72,7 +73,7 @@ class Retroarch(Plugin):
         #removes games when removed while running
         for entry in self.game_cache:
             if entry not in game_list:
-                self.game_cache.remove(entry)    
+                self.game_cache.remove(entry)
                 self.remove_game(entry.game_id)
 
     #runs update_game_cache in case it is started before get_owned_games. If it runs after it, it just returns self.game_cache with each game as installed
@@ -94,7 +95,7 @@ class Retroarch(Plugin):
     def shutdown(self):
         pass
 
-    #potentially give user more customization possibilities like starting in fullscreen etc 
+    #potentially give user more customization possibilities like starting in fullscreen etc
     async def launch_game(self, game_id):
         if os.path.isfile(self.playlist_path):
             with open(self.playlist_path) as playlist_json:
@@ -135,7 +136,7 @@ class Retroarch(Plugin):
                 self.proc = None
         except AttributeError:
             pass
-            
+
         self.update_game_cache()
         self.get_local_games()
 

--- a/gba_16a78ef5-fba6-4629-b83c-ef47adab5aab/plugin.py
+++ b/gba_16a78ef5-fba6-4629-b83c-ef47adab5aab/plugin.py
@@ -49,7 +49,7 @@ class Retroarch(Plugin):
                 playlist_dict = json.load(playlist_json)
             for entry in playlist_dict["items"]:
                 rom_path = entry["path"].split("#")[0]
-if os.path.abspath(user_config.rom_path) in os.path.abspath(rom_path) and os.path.isfile(rom_path):
+                if os.path.abspath(user_config.rom_path) in os.path.abspath(rom_path) and os.path.isfile(rom_path):
                     provided_name = entry["label"].split(" (")[0]
                     if provided_name in corrections.correction_list:
                         correct_name = corrections.correction_list[provided_name]

--- a/gba_16a78ef5-fba6-4629-b83c-ef47adab5aab/plugin.py
+++ b/gba_16a78ef5-fba6-4629-b83c-ef47adab5aab/plugin.py
@@ -48,11 +48,12 @@ class Retroarch(Plugin):
             with open(self.playlist_path) as playlist_json:
                 playlist_dict = json.load(playlist_json)
             for entry in playlist_dict["items"]:
-                if os.path.abspath(user_config.rom_path) in os.path.abspath(entry["path"]) and os.path.isfile(entry["path"]):
+                rom_path = entry["path"].split("#")[0]
+if os.path.abspath(user_config.rom_path) in os.path.abspath(rom_path) and os.path.isfile(rom_path):
                     provided_name = entry["label"].split(" (")[0]
                     if provided_name in corrections.correction_list:
                         correct_name = corrections.correction_list[provided_name]
-                    else:    
+                    else:
                         correct_name = provided_name
                     game_list.append(
                         Game(
@@ -72,7 +73,7 @@ class Retroarch(Plugin):
         #removes games when removed while running
         for entry in self.game_cache:
             if entry not in game_list:
-                self.game_cache.remove(entry)    
+                self.game_cache.remove(entry)
                 self.remove_game(entry.game_id)
 
     #runs update_game_cache in case it is started before get_owned_games. If it runs after it, it just returns self.game_cache with each game as installed
@@ -94,7 +95,7 @@ class Retroarch(Plugin):
     def shutdown(self):
         pass
 
-    #potentially give user more customization possibilities like starting in fullscreen etc 
+    #potentially give user more customization possibilities like starting in fullscreen etc
     async def launch_game(self, game_id):
         if os.path.isfile(self.playlist_path):
             with open(self.playlist_path) as playlist_json:
@@ -135,7 +136,7 @@ class Retroarch(Plugin):
                 self.proc = None
         except AttributeError:
             pass
-            
+
         self.update_game_cache()
         self.get_local_games()
 

--- a/gbc_9b53fc85-af7c-4ce2-af31-0d95234d783a/plugin.py
+++ b/gbc_9b53fc85-af7c-4ce2-af31-0d95234d783a/plugin.py
@@ -49,7 +49,7 @@ class Retroarch(Plugin):
                 playlist_dict = json.load(playlist_json)
             for entry in playlist_dict["items"]:
                 rom_path = entry["path"].split("#")[0]
-if os.path.abspath(user_config.rom_path) in os.path.abspath(rom_path) and os.path.isfile(rom_path):
+                if os.path.abspath(user_config.rom_path) in os.path.abspath(rom_path) and os.path.isfile(rom_path):
                     provided_name = entry["label"].split(" (")[0]
                     if provided_name in corrections.correction_list:
                         correct_name = corrections.correction_list[provided_name]

--- a/gbc_9b53fc85-af7c-4ce2-af31-0d95234d783a/plugin.py
+++ b/gbc_9b53fc85-af7c-4ce2-af31-0d95234d783a/plugin.py
@@ -48,11 +48,12 @@ class Retroarch(Plugin):
             with open(self.playlist_path) as playlist_json:
                 playlist_dict = json.load(playlist_json)
             for entry in playlist_dict["items"]:
-                if os.path.abspath(user_config.rom_path) in os.path.abspath(entry["path"]) and os.path.isfile(entry["path"]):
+                rom_path = entry["path"].split("#")[0]
+if os.path.abspath(user_config.rom_path) in os.path.abspath(rom_path) and os.path.isfile(rom_path):
                     provided_name = entry["label"].split(" (")[0]
                     if provided_name in corrections.correction_list:
                         correct_name = corrections.correction_list[provided_name]
-                    else:    
+                    else:
                         correct_name = provided_name
                     game_list.append(
                         Game(
@@ -72,7 +73,7 @@ class Retroarch(Plugin):
         #removes games when removed while running
         for entry in self.game_cache:
             if entry not in game_list:
-                self.game_cache.remove(entry)    
+                self.game_cache.remove(entry)
                 self.remove_game(entry.game_id)
 
     #runs update_game_cache in case it is started before get_owned_games. If it runs after it, it just returns self.game_cache with each game as installed
@@ -94,7 +95,7 @@ class Retroarch(Plugin):
     def shutdown(self):
         pass
 
-    #potentially give user more customization possibilities like starting in fullscreen etc 
+    #potentially give user more customization possibilities like starting in fullscreen etc
     async def launch_game(self, game_id):
         if os.path.isfile(self.playlist_path):
             with open(self.playlist_path) as playlist_json:
@@ -135,7 +136,7 @@ class Retroarch(Plugin):
                 self.proc = None
         except AttributeError:
             pass
-            
+
         self.update_game_cache()
         self.get_local_games()
 

--- a/jaguar_b9773549-9c20-4729-b23d-f683762ce73a/plugin.py
+++ b/jaguar_b9773549-9c20-4729-b23d-f683762ce73a/plugin.py
@@ -49,7 +49,7 @@ class Retroarch(Plugin):
                 playlist_dict = json.load(playlist_json)
             for entry in playlist_dict["items"]:
                 rom_path = entry["path"].split("#")[0]
-if os.path.abspath(user_config.rom_path) in os.path.abspath(rom_path) and os.path.isfile(rom_path):
+                if os.path.abspath(user_config.rom_path) in os.path.abspath(rom_path) and os.path.isfile(rom_path):
                     provided_name = entry["label"].split(" (")[0]
                     if provided_name in corrections.correction_list:
                         correct_name = corrections.correction_list[provided_name]

--- a/jaguar_b9773549-9c20-4729-b23d-f683762ce73a/plugin.py
+++ b/jaguar_b9773549-9c20-4729-b23d-f683762ce73a/plugin.py
@@ -48,11 +48,12 @@ class Retroarch(Plugin):
             with open(self.playlist_path) as playlist_json:
                 playlist_dict = json.load(playlist_json)
             for entry in playlist_dict["items"]:
-                if os.path.abspath(user_config.rom_path) in os.path.abspath(entry["path"]) and os.path.isfile(entry["path"]):
+                rom_path = entry["path"].split("#")[0]
+if os.path.abspath(user_config.rom_path) in os.path.abspath(rom_path) and os.path.isfile(rom_path):
                     provided_name = entry["label"].split(" (")[0]
                     if provided_name in corrections.correction_list:
                         correct_name = corrections.correction_list[provided_name]
-                    else:    
+                    else:
                         correct_name = provided_name
                     game_list.append(
                         Game(
@@ -72,7 +73,7 @@ class Retroarch(Plugin):
         #removes games when removed while running
         for entry in self.game_cache:
             if entry not in game_list:
-                self.game_cache.remove(entry)    
+                self.game_cache.remove(entry)
                 self.remove_game(entry.game_id)
 
     #runs update_game_cache in case it is started before get_owned_games. If it runs after it, it just returns self.game_cache with each game as installed
@@ -94,7 +95,7 @@ class Retroarch(Plugin):
     def shutdown(self):
         pass
 
-    #potentially give user more customization possibilities like starting in fullscreen etc 
+    #potentially give user more customization possibilities like starting in fullscreen etc
     async def launch_game(self, game_id):
         if os.path.isfile(self.playlist_path):
             with open(self.playlist_path) as playlist_json:
@@ -135,7 +136,7 @@ class Retroarch(Plugin):
                 self.proc = None
         except AttributeError:
             pass
-            
+
         self.update_game_cache()
         self.get_local_games()
 

--- a/n64_a3824d31-c2d3-4a1a-b321-7d0764da5513/plugin.py
+++ b/n64_a3824d31-c2d3-4a1a-b321-7d0764da5513/plugin.py
@@ -50,7 +50,7 @@ class Retroarch(Plugin):
                 playlist_dict = json.load(playlist_json)
             for entry in playlist_dict["items"]:
                 rom_path = entry["path"].split("#")[0]
-if os.path.abspath(user_config.rom_path) in os.path.abspath(rom_path) and os.path.isfile(rom_path):
+                if os.path.abspath(user_config.rom_path) in os.path.abspath(rom_path) and os.path.isfile(rom_path):
                     provided_name = entry["label"].split(" (")[0]
                     if provided_name in corrections.correction_list:
                         correct_name = corrections.correction_list[provided_name]

--- a/n64_a3824d31-c2d3-4a1a-b321-7d0764da5513/plugin.py
+++ b/n64_a3824d31-c2d3-4a1a-b321-7d0764da5513/plugin.py
@@ -49,11 +49,12 @@ class Retroarch(Plugin):
             with open(self.playlist_path) as playlist_json:
                 playlist_dict = json.load(playlist_json)
             for entry in playlist_dict["items"]:
-                if os.path.abspath(user_config.rom_path) in os.path.abspath(entry["path"]) and os.path.isfile(entry["path"]):
+                rom_path = entry["path"].split("#")[0]
+if os.path.abspath(user_config.rom_path) in os.path.abspath(rom_path) and os.path.isfile(rom_path):
                     provided_name = entry["label"].split(" (")[0]
                     if provided_name in corrections.correction_list:
                         correct_name = corrections.correction_list[provided_name]
-                    else:    
+                    else:
                         correct_name = provided_name
                     game_list.append(
                         Game(
@@ -95,7 +96,7 @@ class Retroarch(Plugin):
     def shutdown(self):
         pass
 
-    #potentially give user more customization possibilities like starting in fullscreen etc 
+    #potentially give user more customization possibilities like starting in fullscreen etc
     async def launch_game(self, game_id):
         if os.path.isfile(self.playlist_path):
             with open(self.playlist_path) as playlist_json:
@@ -136,13 +137,13 @@ class Retroarch(Plugin):
                 self.proc = None
         except AttributeError:
             pass
-            
+
         self.update_game_cache()
         self.get_local_games()
-        
+
 
 def main():
     create_and_run_plugin(Retroarch, sys.argv)
-    
+
 if __name__ == "__main__":
     main()

--- a/ncube_602422b9-ced5-476e-911a-7fa0adf0f7f7/plugin.py
+++ b/ncube_602422b9-ced5-476e-911a-7fa0adf0f7f7/plugin.py
@@ -49,7 +49,7 @@ class Retroarch(Plugin):
                 playlist_dict = json.load(playlist_json)
             for entry in playlist_dict["items"]:
                 rom_path = entry["path"].split("#")[0]
-if os.path.abspath(user_config.rom_path) in os.path.abspath(rom_path) and os.path.isfile(rom_path):
+                if os.path.abspath(user_config.rom_path) in os.path.abspath(rom_path) and os.path.isfile(rom_path):
                     provided_name = entry["label"].split(" (")[0]
                     if provided_name in corrections.correction_list:
                         correct_name = corrections.correction_list[provided_name]

--- a/ncube_602422b9-ced5-476e-911a-7fa0adf0f7f7/plugin.py
+++ b/ncube_602422b9-ced5-476e-911a-7fa0adf0f7f7/plugin.py
@@ -48,11 +48,12 @@ class Retroarch(Plugin):
             with open(self.playlist_path) as playlist_json:
                 playlist_dict = json.load(playlist_json)
             for entry in playlist_dict["items"]:
-                if os.path.abspath(user_config.rom_path) in os.path.abspath(entry["path"]) and os.path.isfile(entry["path"]):
+                rom_path = entry["path"].split("#")[0]
+if os.path.abspath(user_config.rom_path) in os.path.abspath(rom_path) and os.path.isfile(rom_path):
                     provided_name = entry["label"].split(" (")[0]
                     if provided_name in corrections.correction_list:
                         correct_name = corrections.correction_list[provided_name]
-                    else:    
+                    else:
                         correct_name = provided_name
                     game_list.append(
                         Game(
@@ -72,7 +73,7 @@ class Retroarch(Plugin):
         #removes games when removed while running
         for entry in self.game_cache:
             if entry not in game_list:
-                self.game_cache.remove(entry)    
+                self.game_cache.remove(entry)
                 self.remove_game(entry.game_id)
 
     #runs update_game_cache in case it is started before get_owned_games. If it runs after it, it just returns self.game_cache with each game as installed
@@ -94,7 +95,7 @@ class Retroarch(Plugin):
     def shutdown(self):
         pass
 
-    #potentially give user more customization possibilities like starting in fullscreen etc 
+    #potentially give user more customization possibilities like starting in fullscreen etc
     async def launch_game(self, game_id):
         if os.path.isfile(self.playlist_path):
             with open(self.playlist_path) as playlist_json:
@@ -135,7 +136,7 @@ class Retroarch(Plugin):
                 self.proc = None
         except AttributeError:
             pass
-            
+
         self.update_game_cache()
         self.get_local_games()
 

--- a/nds_4704ed29-f516-4fd8-8477-ddbcdb7cedfc/plugin.py
+++ b/nds_4704ed29-f516-4fd8-8477-ddbcdb7cedfc/plugin.py
@@ -49,7 +49,7 @@ class Retroarch(Plugin):
                 playlist_dict = json.load(playlist_json)
             for entry in playlist_dict["items"]:
                 rom_path = entry["path"].split("#")[0]
-if os.path.abspath(user_config.rom_path) in os.path.abspath(rom_path) and os.path.isfile(rom_path):
+                if os.path.abspath(user_config.rom_path) in os.path.abspath(rom_path) and os.path.isfile(rom_path):
                     provided_name = entry["label"].split(" (")[0]
                     if provided_name in corrections.correction_list:
                         correct_name = corrections.correction_list[provided_name]

--- a/nds_4704ed29-f516-4fd8-8477-ddbcdb7cedfc/plugin.py
+++ b/nds_4704ed29-f516-4fd8-8477-ddbcdb7cedfc/plugin.py
@@ -48,11 +48,12 @@ class Retroarch(Plugin):
             with open(self.playlist_path) as playlist_json:
                 playlist_dict = json.load(playlist_json)
             for entry in playlist_dict["items"]:
-                if os.path.abspath(user_config.rom_path) in os.path.abspath(entry["path"]) and os.path.isfile(entry["path"]):
+                rom_path = entry["path"].split("#")[0]
+if os.path.abspath(user_config.rom_path) in os.path.abspath(rom_path) and os.path.isfile(rom_path):
                     provided_name = entry["label"].split(" (")[0]
                     if provided_name in corrections.correction_list:
                         correct_name = corrections.correction_list[provided_name]
-                    else:    
+                    else:
                         correct_name = provided_name
                     game_list.append(
                         Game(
@@ -72,7 +73,7 @@ class Retroarch(Plugin):
         #removes games when removed while running
         for entry in self.game_cache:
             if entry not in game_list:
-                self.game_cache.remove(entry)    
+                self.game_cache.remove(entry)
                 self.remove_game(entry.game_id)
 
     #runs update_game_cache in case it is started before get_owned_games. If it runs after it, it just returns self.game_cache with each game as installed
@@ -94,7 +95,7 @@ class Retroarch(Plugin):
     def shutdown(self):
         pass
 
-    #potentially give user more customization possibilities like starting in fullscreen etc 
+    #potentially give user more customization possibilities like starting in fullscreen etc
     async def launch_game(self, game_id):
         if os.path.isfile(self.playlist_path):
             with open(self.playlist_path) as playlist_json:
@@ -135,7 +136,7 @@ class Retroarch(Plugin):
                 self.proc = None
         except AttributeError:
             pass
-            
+
         self.update_game_cache()
         self.get_local_games()
 

--- a/nes_e2c630e1-3cbe-4dbd-9235-5e6a2d2955ad/plugin.py
+++ b/nes_e2c630e1-3cbe-4dbd-9235-5e6a2d2955ad/plugin.py
@@ -49,7 +49,7 @@ class Retroarch(Plugin):
                 playlist_dict = json.load(playlist_json)
             for entry in playlist_dict["items"]:
                 rom_path = entry["path"].split("#")[0]
-if os.path.abspath(user_config.rom_path) in os.path.abspath(rom_path) and os.path.isfile(rom_path):
+                if os.path.abspath(user_config.rom_path) in os.path.abspath(rom_path) and os.path.isfile(rom_path):
                     provided_name = entry["label"].split(" (")[0]
                     if provided_name in corrections.correction_list:
                         correct_name = corrections.correction_list[provided_name]

--- a/nes_e2c630e1-3cbe-4dbd-9235-5e6a2d2955ad/plugin.py
+++ b/nes_e2c630e1-3cbe-4dbd-9235-5e6a2d2955ad/plugin.py
@@ -48,11 +48,12 @@ class Retroarch(Plugin):
             with open(self.playlist_path) as playlist_json:
                 playlist_dict = json.load(playlist_json)
             for entry in playlist_dict["items"]:
-                if os.path.abspath(user_config.rom_path) in os.path.abspath(entry["path"]) and os.path.isfile(entry["path"]):
+                rom_path = entry["path"].split("#")[0]
+if os.path.abspath(user_config.rom_path) in os.path.abspath(rom_path) and os.path.isfile(rom_path):
                     provided_name = entry["label"].split(" (")[0]
                     if provided_name in corrections.correction_list:
                         correct_name = corrections.correction_list[provided_name]
-                    else:    
+                    else:
                         correct_name = provided_name
                     game_list.append(
                         Game(
@@ -72,7 +73,7 @@ class Retroarch(Plugin):
         #removes games when removed while running
         for entry in self.game_cache:
             if entry not in game_list:
-                self.game_cache.remove(entry)    
+                self.game_cache.remove(entry)
                 self.remove_game(entry.game_id)
 
     #runs update_game_cache in case it is started before get_owned_games. If it runs after it, it just returns self.game_cache with each game as installed
@@ -94,7 +95,7 @@ class Retroarch(Plugin):
     def shutdown(self):
         pass
 
-    #potentially give user more customization possibilities like starting in fullscreen etc 
+    #potentially give user more customization possibilities like starting in fullscreen etc
     async def launch_game(self, game_id):
         if os.path.isfile(self.playlist_path):
             with open(self.playlist_path) as playlist_json:
@@ -135,7 +136,7 @@ class Retroarch(Plugin):
                 self.proc = None
         except AttributeError:
             pass
-            
+
         self.update_game_cache()
         self.get_local_games()
 

--- a/nwii_2d0e97ac-0406-4e5f-a85b-ab5b1a042cba/plugin.py
+++ b/nwii_2d0e97ac-0406-4e5f-a85b-ab5b1a042cba/plugin.py
@@ -49,7 +49,7 @@ class Retroarch(Plugin):
                 playlist_dict = json.load(playlist_json)
             for entry in playlist_dict["items"]:
                 rom_path = entry["path"].split("#")[0]
-if os.path.abspath(user_config.rom_path) in os.path.abspath(rom_path) and os.path.isfile(rom_path):
+                if os.path.abspath(user_config.rom_path) in os.path.abspath(rom_path) and os.path.isfile(rom_path):
                     provided_name = entry["label"].split(" (")[0]
                     if provided_name in corrections.correction_list:
                         correct_name = corrections.correction_list[provided_name]

--- a/nwii_2d0e97ac-0406-4e5f-a85b-ab5b1a042cba/plugin.py
+++ b/nwii_2d0e97ac-0406-4e5f-a85b-ab5b1a042cba/plugin.py
@@ -48,11 +48,12 @@ class Retroarch(Plugin):
             with open(self.playlist_path) as playlist_json:
                 playlist_dict = json.load(playlist_json)
             for entry in playlist_dict["items"]:
-                if os.path.abspath(user_config.rom_path) in os.path.abspath(entry["path"]) and os.path.isfile(entry["path"]):
+                rom_path = entry["path"].split("#")[0]
+if os.path.abspath(user_config.rom_path) in os.path.abspath(rom_path) and os.path.isfile(rom_path):
                     provided_name = entry["label"].split(" (")[0]
                     if provided_name in corrections.correction_list:
                         correct_name = corrections.correction_list[provided_name]
-                    else:    
+                    else:
                         correct_name = provided_name
                     game_list.append(
                         Game(
@@ -72,7 +73,7 @@ class Retroarch(Plugin):
         #removes games when removed while running
         for entry in self.game_cache:
             if entry not in game_list:
-                self.game_cache.remove(entry)    
+                self.game_cache.remove(entry)
                 self.remove_game(entry.game_id)
 
     #runs update_game_cache in case it is started before get_owned_games. If it runs after it, it just returns self.game_cache with each game as installed
@@ -94,7 +95,7 @@ class Retroarch(Plugin):
     def shutdown(self):
         pass
 
-    #potentially give user more customization possibilities like starting in fullscreen etc 
+    #potentially give user more customization possibilities like starting in fullscreen etc
     async def launch_game(self, game_id):
         if os.path.isfile(self.playlist_path):
             with open(self.playlist_path) as playlist_json:
@@ -135,7 +136,7 @@ class Retroarch(Plugin):
                 self.proc = None
         except AttributeError:
             pass
-            
+
         self.update_game_cache()
         self.get_local_games()
 

--- a/ps1_ff02c67d-5962-4e79-a3a3-928814edb270/plugin.py
+++ b/ps1_ff02c67d-5962-4e79-a3a3-928814edb270/plugin.py
@@ -49,7 +49,7 @@ class Retroarch(Plugin):
                 playlist_dict = json.load(playlist_json)
             for entry in playlist_dict["items"]:
                 rom_path = entry["path"].split("#")[0]
-if os.path.abspath(user_config.rom_path) in os.path.abspath(rom_path) and os.path.isfile(rom_path):
+                if os.path.abspath(user_config.rom_path) in os.path.abspath(rom_path) and os.path.isfile(rom_path):
                     provided_name = entry["label"].split(" (")[0]
                     if provided_name in corrections.correction_list:
                         correct_name = corrections.correction_list[provided_name]

--- a/ps1_ff02c67d-5962-4e79-a3a3-928814edb270/plugin.py
+++ b/ps1_ff02c67d-5962-4e79-a3a3-928814edb270/plugin.py
@@ -48,11 +48,12 @@ class Retroarch(Plugin):
             with open(self.playlist_path) as playlist_json:
                 playlist_dict = json.load(playlist_json)
             for entry in playlist_dict["items"]:
-                if os.path.abspath(user_config.rom_path) in os.path.abspath(entry["path"]) and os.path.isfile(entry["path"]):
+                rom_path = entry["path"].split("#")[0]
+if os.path.abspath(user_config.rom_path) in os.path.abspath(rom_path) and os.path.isfile(rom_path):
                     provided_name = entry["label"].split(" (")[0]
                     if provided_name in corrections.correction_list:
                         correct_name = corrections.correction_list[provided_name]
-                    else:    
+                    else:
                         correct_name = provided_name
                     game_list.append(
                         Game(
@@ -72,7 +73,7 @@ class Retroarch(Plugin):
         #removes games when removed while running
         for entry in self.game_cache:
             if entry not in game_list:
-                self.game_cache.remove(entry)    
+                self.game_cache.remove(entry)
                 self.remove_game(entry.game_id)
 
     #runs update_game_cache in case it is started before get_owned_games. If it runs after it, it just returns self.game_cache with each game as installed
@@ -94,7 +95,7 @@ class Retroarch(Plugin):
     def shutdown(self):
         pass
 
-    #potentially give user more customization possibilities like starting in fullscreen etc 
+    #potentially give user more customization possibilities like starting in fullscreen etc
     async def launch_game(self, game_id):
         if os.path.isfile(self.playlist_path):
             with open(self.playlist_path) as playlist_json:
@@ -135,7 +136,7 @@ class Retroarch(Plugin):
                 self.proc = None
         except AttributeError:
             pass
-            
+
         self.update_game_cache()
         self.get_local_games()
 

--- a/psp_05487532-ba29-411b-b799-784262d275bd/plugin.py
+++ b/psp_05487532-ba29-411b-b799-784262d275bd/plugin.py
@@ -49,7 +49,7 @@ class Retroarch(Plugin):
                 playlist_dict = json.load(playlist_json)
             for entry in playlist_dict["items"]:
                 rom_path = entry["path"].split("#")[0]
-if os.path.abspath(user_config.rom_path) in os.path.abspath(rom_path) and os.path.isfile(rom_path):
+                if os.path.abspath(user_config.rom_path) in os.path.abspath(rom_path) and os.path.isfile(rom_path):
                     provided_name = entry["label"].split(" (")[0]
                     if provided_name in corrections.correction_list:
                         correct_name = corrections.correction_list[provided_name]

--- a/psp_05487532-ba29-411b-b799-784262d275bd/plugin.py
+++ b/psp_05487532-ba29-411b-b799-784262d275bd/plugin.py
@@ -48,11 +48,12 @@ class Retroarch(Plugin):
             with open(self.playlist_path) as playlist_json:
                 playlist_dict = json.load(playlist_json)
             for entry in playlist_dict["items"]:
-                if os.path.abspath(user_config.rom_path) in os.path.abspath(entry["path"]) and os.path.isfile(entry["path"]):
+                rom_path = entry["path"].split("#")[0]
+if os.path.abspath(user_config.rom_path) in os.path.abspath(rom_path) and os.path.isfile(rom_path):
                     provided_name = entry["label"].split(" (")[0]
                     if provided_name in corrections.correction_list:
                         correct_name = corrections.correction_list[provided_name]
-                    else:    
+                    else:
                         correct_name = provided_name
                     game_list.append(
                         Game(
@@ -72,7 +73,7 @@ class Retroarch(Plugin):
         #removes games when removed while running
         for entry in self.game_cache:
             if entry not in game_list:
-                self.game_cache.remove(entry)    
+                self.game_cache.remove(entry)
                 self.remove_game(entry.game_id)
 
     #runs update_game_cache in case it is started before get_owned_games. If it runs after it, it just returns self.game_cache with each game as installed
@@ -94,7 +95,7 @@ class Retroarch(Plugin):
     def shutdown(self):
         pass
 
-    #potentially give user more customization possibilities like starting in fullscreen etc 
+    #potentially give user more customization possibilities like starting in fullscreen etc
     async def launch_game(self, game_id):
         if os.path.isfile(self.playlist_path):
             with open(self.playlist_path) as playlist_json:
@@ -135,7 +136,7 @@ class Retroarch(Plugin):
                 self.proc = None
         except AttributeError:
             pass
-            
+
         self.update_game_cache()
         self.get_local_games()
 

--- a/saturn_bd6ec091-8ee0-440a-9e26-71bbf21c05af/plugin.py
+++ b/saturn_bd6ec091-8ee0-440a-9e26-71bbf21c05af/plugin.py
@@ -49,7 +49,7 @@ class Retroarch(Plugin):
                 playlist_dict = json.load(playlist_json)
             for entry in playlist_dict["items"]:
                 rom_path = entry["path"].split("#")[0]
-if os.path.abspath(user_config.rom_path) in os.path.abspath(rom_path) and os.path.isfile(rom_path):
+                if os.path.abspath(user_config.rom_path) in os.path.abspath(rom_path) and os.path.isfile(rom_path):
                     provided_name = entry["label"].split(" (")[0]
                     if provided_name in corrections.correction_list:
                         correct_name = corrections.correction_list[provided_name]

--- a/saturn_bd6ec091-8ee0-440a-9e26-71bbf21c05af/plugin.py
+++ b/saturn_bd6ec091-8ee0-440a-9e26-71bbf21c05af/plugin.py
@@ -48,11 +48,12 @@ class Retroarch(Plugin):
             with open(self.playlist_path) as playlist_json:
                 playlist_dict = json.load(playlist_json)
             for entry in playlist_dict["items"]:
-                if os.path.abspath(user_config.rom_path) in os.path.abspath(entry["path"]) and os.path.isfile(entry["path"]):
+                rom_path = entry["path"].split("#")[0]
+if os.path.abspath(user_config.rom_path) in os.path.abspath(rom_path) and os.path.isfile(rom_path):
                     provided_name = entry["label"].split(" (")[0]
                     if provided_name in corrections.correction_list:
                         correct_name = corrections.correction_list[provided_name]
-                    else:    
+                    else:
                         correct_name = provided_name
                     game_list.append(
                         Game(
@@ -72,7 +73,7 @@ class Retroarch(Plugin):
         #removes games when removed while running
         for entry in self.game_cache:
             if entry not in game_list:
-                self.game_cache.remove(entry)    
+                self.game_cache.remove(entry)
                 self.remove_game(entry.game_id)
 
     #runs update_game_cache in case it is started before get_owned_games. If it runs after it, it just returns self.game_cache with each game as installed
@@ -94,7 +95,7 @@ class Retroarch(Plugin):
     def shutdown(self):
         pass
 
-    #potentially give user more customization possibilities like starting in fullscreen etc 
+    #potentially give user more customization possibilities like starting in fullscreen etc
     async def launch_game(self, game_id):
         if os.path.isfile(self.playlist_path):
             with open(self.playlist_path) as playlist_json:
@@ -135,7 +136,7 @@ class Retroarch(Plugin):
                 self.proc = None
         except AttributeError:
             pass
-            
+
         self.update_game_cache()
         self.get_local_games()
 

--- a/segacd_ec7197bf-a4e4-4b86-81b9-38ea7d56f3b2/plugin.py
+++ b/segacd_ec7197bf-a4e4-4b86-81b9-38ea7d56f3b2/plugin.py
@@ -49,7 +49,7 @@ class Retroarch(Plugin):
                 playlist_dict = json.load(playlist_json)
             for entry in playlist_dict["items"]:
                 rom_path = entry["path"].split("#")[0]
-if os.path.abspath(user_config.rom_path) in os.path.abspath(rom_path) and os.path.isfile(rom_path):
+                if os.path.abspath(user_config.rom_path) in os.path.abspath(rom_path) and os.path.isfile(rom_path):
                     provided_name = entry["label"].split(" (")[0]
                     if provided_name in corrections.correction_list:
                         correct_name = corrections.correction_list[provided_name]

--- a/segacd_ec7197bf-a4e4-4b86-81b9-38ea7d56f3b2/plugin.py
+++ b/segacd_ec7197bf-a4e4-4b86-81b9-38ea7d56f3b2/plugin.py
@@ -48,11 +48,12 @@ class Retroarch(Plugin):
             with open(self.playlist_path) as playlist_json:
                 playlist_dict = json.load(playlist_json)
             for entry in playlist_dict["items"]:
-                if os.path.abspath(user_config.rom_path) in os.path.abspath(entry["path"]) and os.path.isfile(entry["path"]):
+                rom_path = entry["path"].split("#")[0]
+if os.path.abspath(user_config.rom_path) in os.path.abspath(rom_path) and os.path.isfile(rom_path):
                     provided_name = entry["label"].split(" (")[0]
                     if provided_name in corrections.correction_list:
                         correct_name = corrections.correction_list[provided_name]
-                    else:    
+                    else:
                         correct_name = provided_name
                     game_list.append(
                         Game(
@@ -72,7 +73,7 @@ class Retroarch(Plugin):
         #removes games when removed while running
         for entry in self.game_cache:
             if entry not in game_list:
-                self.game_cache.remove(entry)    
+                self.game_cache.remove(entry)
                 self.remove_game(entry.game_id)
 
     #runs update_game_cache in case it is started before get_owned_games. If it runs after it, it just returns self.game_cache with each game as installed
@@ -94,7 +95,7 @@ class Retroarch(Plugin):
     def shutdown(self):
         pass
 
-    #potentially give user more customization possibilities like starting in fullscreen etc 
+    #potentially give user more customization possibilities like starting in fullscreen etc
     async def launch_game(self, game_id):
         if os.path.isfile(self.playlist_path):
             with open(self.playlist_path) as playlist_json:
@@ -135,7 +136,7 @@ class Retroarch(Plugin):
                 self.proc = None
         except AttributeError:
             pass
-            
+
         self.update_game_cache()
         self.get_local_games()
 

--- a/segag_e3ac94e7-945e-459d-bc1e-676cff8173f9/plugin.py
+++ b/segag_e3ac94e7-945e-459d-bc1e-676cff8173f9/plugin.py
@@ -49,7 +49,7 @@ class Retroarch(Plugin):
                 playlist_dict = json.load(playlist_json)
             for entry in playlist_dict["items"]:
                 rom_path = entry["path"].split("#")[0]
-if os.path.abspath(user_config.rom_path) in os.path.abspath(rom_path) and os.path.isfile(rom_path):
+                if os.path.abspath(user_config.rom_path) in os.path.abspath(rom_path) and os.path.isfile(rom_path):
                     provided_name = entry["label"].split(" (")[0]
                     if provided_name in corrections.correction_list:
                         correct_name = corrections.correction_list[provided_name]

--- a/segag_e3ac94e7-945e-459d-bc1e-676cff8173f9/plugin.py
+++ b/segag_e3ac94e7-945e-459d-bc1e-676cff8173f9/plugin.py
@@ -48,11 +48,12 @@ class Retroarch(Plugin):
             with open(self.playlist_path) as playlist_json:
                 playlist_dict = json.load(playlist_json)
             for entry in playlist_dict["items"]:
-                if os.path.abspath(user_config.rom_path) in os.path.abspath(entry["path"]) and os.path.isfile(entry["path"]):
+                rom_path = entry["path"].split("#")[0]
+if os.path.abspath(user_config.rom_path) in os.path.abspath(rom_path) and os.path.isfile(rom_path):
                     provided_name = entry["label"].split(" (")[0]
                     if provided_name in corrections.correction_list:
                         correct_name = corrections.correction_list[provided_name]
-                    else:    
+                    else:
                         correct_name = provided_name
                     game_list.append(
                         Game(
@@ -72,7 +73,7 @@ class Retroarch(Plugin):
         #removes games when removed while running
         for entry in self.game_cache:
             if entry not in game_list:
-                self.game_cache.remove(entry)    
+                self.game_cache.remove(entry)
                 self.remove_game(entry.game_id)
 
     #runs update_game_cache in case it is started before get_owned_games. If it runs after it, it just returns self.game_cache with each game as installed
@@ -94,7 +95,7 @@ class Retroarch(Plugin):
     def shutdown(self):
         pass
 
-    #potentially give user more customization possibilities like starting in fullscreen etc 
+    #potentially give user more customization possibilities like starting in fullscreen etc
     async def launch_game(self, game_id):
         if os.path.isfile(self.playlist_path):
             with open(self.playlist_path) as playlist_json:
@@ -135,7 +136,7 @@ class Retroarch(Plugin):
                 self.proc = None
         except AttributeError:
             pass
-            
+
         self.update_game_cache()
         self.get_local_games()
 

--- a/sms_c6689bfb-7ba4-4d24-98e3-bd2dc339926b/plugin.py
+++ b/sms_c6689bfb-7ba4-4d24-98e3-bd2dc339926b/plugin.py
@@ -49,7 +49,7 @@ class Retroarch(Plugin):
                 playlist_dict = json.load(playlist_json)
             for entry in playlist_dict["items"]:
                 rom_path = entry["path"].split("#")[0]
-if os.path.abspath(user_config.rom_path) in os.path.abspath(rom_path) and os.path.isfile(rom_path):
+                if os.path.abspath(user_config.rom_path) in os.path.abspath(rom_path) and os.path.isfile(rom_path):
                     provided_name = entry["label"].split(" (")[0]
                     if provided_name in corrections.correction_list:
                         correct_name = corrections.correction_list[provided_name]

--- a/sms_c6689bfb-7ba4-4d24-98e3-bd2dc339926b/plugin.py
+++ b/sms_c6689bfb-7ba4-4d24-98e3-bd2dc339926b/plugin.py
@@ -48,11 +48,12 @@ class Retroarch(Plugin):
             with open(self.playlist_path) as playlist_json:
                 playlist_dict = json.load(playlist_json)
             for entry in playlist_dict["items"]:
-                if os.path.abspath(user_config.rom_path) in os.path.abspath(entry["path"]) and os.path.isfile(entry["path"]):
+                rom_path = entry["path"].split("#")[0]
+if os.path.abspath(user_config.rom_path) in os.path.abspath(rom_path) and os.path.isfile(rom_path):
                     provided_name = entry["label"].split(" (")[0]
                     if provided_name in corrections.correction_list:
                         correct_name = corrections.correction_list[provided_name]
-                    else:    
+                    else:
                         correct_name = provided_name
                     game_list.append(
                         Game(
@@ -72,7 +73,7 @@ class Retroarch(Plugin):
         #removes games when removed while running
         for entry in self.game_cache:
             if entry not in game_list:
-                self.game_cache.remove(entry)    
+                self.game_cache.remove(entry)
                 self.remove_game(entry.game_id)
 
     #runs update_game_cache in case it is started before get_owned_games. If it runs after it, it just returns self.game_cache with each game as installed
@@ -94,7 +95,7 @@ class Retroarch(Plugin):
     def shutdown(self):
         pass
 
-    #potentially give user more customization possibilities like starting in fullscreen etc 
+    #potentially give user more customization possibilities like starting in fullscreen etc
     async def launch_game(self, game_id):
         if os.path.isfile(self.playlist_path):
             with open(self.playlist_path) as playlist_json:
@@ -135,7 +136,7 @@ class Retroarch(Plugin):
                 self.proc = None
         except AttributeError:
             pass
-            
+
         self.update_game_cache()
         self.get_local_games()
 

--- a/snes_bc831044-f772-4391-8c22-529f42cb9799/plugin.py
+++ b/snes_bc831044-f772-4391-8c22-529f42cb9799/plugin.py
@@ -49,7 +49,7 @@ class Retroarch(Plugin):
                 playlist_dict = json.load(playlist_json)
             for entry in playlist_dict["items"]:
                 rom_path = entry["path"].split("#")[0]
-if os.path.abspath(user_config.rom_path) in os.path.abspath(rom_path) and os.path.isfile(rom_path):
+                if os.path.abspath(user_config.rom_path) in os.path.abspath(rom_path) and os.path.isfile(rom_path):
                     provided_name = entry["label"].split(" (")[0]
                     if provided_name in corrections.correction_list:
                         correct_name = corrections.correction_list[provided_name]

--- a/snes_bc831044-f772-4391-8c22-529f42cb9799/plugin.py
+++ b/snes_bc831044-f772-4391-8c22-529f42cb9799/plugin.py
@@ -48,11 +48,12 @@ class Retroarch(Plugin):
             with open(self.playlist_path) as playlist_json:
                 playlist_dict = json.load(playlist_json)
             for entry in playlist_dict["items"]:
-                if os.path.abspath(user_config.rom_path) in os.path.abspath(entry["path"]) and os.path.isfile(entry["path"]):
+                rom_path = entry["path"].split("#")[0]
+if os.path.abspath(user_config.rom_path) in os.path.abspath(rom_path) and os.path.isfile(rom_path):
                     provided_name = entry["label"].split(" (")[0]
                     if provided_name in corrections.correction_list:
                         correct_name = corrections.correction_list[provided_name]
-                    else:    
+                    else:
                         correct_name = provided_name
                     game_list.append(
                         Game(
@@ -72,7 +73,7 @@ class Retroarch(Plugin):
         #removes games when removed while running
         for entry in self.game_cache:
             if entry not in game_list:
-                self.game_cache.remove(entry)    
+                self.game_cache.remove(entry)
                 self.remove_game(entry.game_id)
 
     #runs update_game_cache in case it is started before get_owned_games. If it runs after it, it just returns self.game_cache with each game as installed
@@ -94,7 +95,7 @@ class Retroarch(Plugin):
     def shutdown(self):
         pass
 
-    #potentially give user more customization possibilities like starting in fullscreen etc 
+    #potentially give user more customization possibilities like starting in fullscreen etc
     async def launch_game(self, game_id):
         if os.path.isfile(self.playlist_path):
             with open(self.playlist_path) as playlist_json:
@@ -135,7 +136,7 @@ class Retroarch(Plugin):
                 self.proc = None
         except AttributeError:
             pass
-            
+
         self.update_game_cache()
         self.get_local_games()
 


### PR DESCRIPTION
**Summary :**
7z, zip, rar... roms archives aren't available in GOG library.

**Why :**
Retroarch .lpl file can contains archive file entries like :
```
"path": "C:\\Emulation\\Roms\\Nintendo - Super Nintendo Entertainment
System\\ActRaiser (USA).7z#ActRaiser (USA).sfc"
```
These paths are ignored by the plugin.

**Acceptance Criterias :**

- [x] Fix rom path check method to support archive files for each platform.